### PR TITLE
Fix: [AEA-0000] - Add ignores to check-licenses

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -125,7 +125,9 @@ jobs:
             poetry run pip install pip-licenses
           fi
 
-          LICENSES=$(poetry run pip-licenses)
+          # known packages with dual licensing
+          IGNORE_PACKAGES="PyGithub chardet text-unidecode"
+          LICENSES=$(poetry run pip-licenses  --ignore-packages ${IGNORE_PACKAGES})
           INCOMPATIBLE_LIBS=$(echo "$LICENSES" | grep 'GPL' || true)
 
           if [[ -z $INCOMPATIBLE_LIBS ]]; then


### PR DESCRIPTION
## Summary

- :sparkles: New Feature

### Details

Brings in the ignored licenses from https://github.com/NHSDigital/electronic-prescription-service-release-notes/blob/main/scripts/check_python_licenses.sh