### PR TITLE
Fix: [AEA-0000] - Fix sonar for java. Fix release tagging flow

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -11,6 +11,11 @@ on:
         description: "If true, the action will install java into the runner, separately from ASDF."
         default: false
         required: false
+      run_sonar:
+        type: boolean
+        description: Toggle to run sonar code analyis on this repository.
+        default: true
+        required: false
 
 jobs:
   quality_checks:
@@ -107,7 +112,22 @@ jobs:
             echo "****************"
             echo "uses_poetry=false" >> $GITHUB_OUTPUT
           fi
-  
+
+      - name: Check if project uses Java
+        id: check_java
+        run: |
+          if [ -f pom.xml ]; then
+            echo "****************"
+            echo "Detected a Java project"
+            echo "****************"
+            echo "uses_java=true" >> $GITHUB_OUTPUT
+          else
+            echo "****************"
+            echo "Project does not use Java"
+            echo "****************"
+            echo "uses_java=false" >> $GITHUB_OUTPUT
+          fi
+    
       - name: Check for SAM templates
         id: check_sam_templates
         run: |
@@ -306,13 +326,16 @@ jobs:
       - name: "check is SONAR_TOKEN exists"
         env: 
             super_secret: ${{ secrets.SONAR_TOKEN }}
-        if: ${{ env.super_secret != '' }}
-        run: echo "RUN_SONAR=true" >> "$GITHUB_ENV"
+        if: ${{ env.super_secret != '' && inputs.run_sonar == 'true' }}
+        run: echo "SONAR_TOKEN_EXISTS=true" >> "$GITHUB_ENV"
 
-      
+      - name: Run SonarQube analysis
+        if: ${{ steps.check_java.outputs.uses_java == 'true' && env.SONAR_TOKEN_EXISTS == 'true' }}
+        run: mvn sonar:sonar -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
-        if: ${{ env.RUN_SONAR == 'true' }}
+        if: ${{ steps.check_java.outputs.uses_java == 'false' && env.SONAR_TOKEN_EXISTS == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/commit-analyzer": "^13.0.0",
         "@semantic-release/release-notes-generator": "^14.0.1",
+        "conventional-changelog-eslint": "^6.0.0",
         "semantic-release": "^24.2.0"
       }
     },
@@ -929,6 +930,16 @@
       "dependencies": {
         "compare-func": "^2.0.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-eslint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
+      "integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
+      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
   "license": "MIT",
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/release-notes-generator": "^14.0.1",
     "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/release-notes-generator": "^14.0.1",
+    "conventional-changelog-eslint": "^6.0.0",
     "semantic-release": "^24.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- :robot: Operational or Infrastructure Change

### Details

This should fix java sonar scanning. Also adds an optional input that can disable sonar altogether:
- If `run_sonar` is false, `SONAR_TOKEN_EXISTS` will be unset/false
- If `run_sonar` is true, and the sonar token is set, then the analysis steps can run
- If it's a Java project, the java one runs
- If it's not a java project, the normal one runs

Also adds a missing package that stopped the release tagging from working.